### PR TITLE
Add comprehensive test coverage and improve documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,13 +105,13 @@ $ azurecost -s my-subscription -r my-resource-group
 
 | Option | Short | Description | Default |
 |--------|-------|-------------|---------|
-| `--subscription` | `-s` | Subscription display name | `AZURE_SUBSCRIPTION_ID` env var |
-| `--resource-group` | `-r` | Filter by resource group | `AZURE_RESOURCE_GROUP` env var |
-| `--dimensions` | `-d` | Aggregation dimensions (can specify multiple) | `ServiceName` |
-| `--granularity` | `-g` | Aggregation granularity (`MONTHLY`/`DAILY`) | `MONTHLY` |
-| `--ago` | `-a` | How many periods ago to fetch from | `1` |
-| `--debug` | - | Enable debug logging | `False` |
-| `--version` | `-v` | Show version | - |
+| `--subscription` | `-s` | Azure subscription display name. Can be omitted if `AZURE_SUBSCRIPTION_ID` environment variable is set. | `AZURE_SUBSCRIPTION_ID` env var |
+| `--resource-group` | `-r` | Filter costs by a specific resource group. Can be omitted if `AZURE_RESOURCE_GROUP` environment variable is set. | `AZURE_RESOURCE_GROUP` env var |
+| `--dimensions` | `-d` | Dimensions to aggregate costs by (e.g., ResourceGroup, ServiceName). Can be specified multiple times. | `ServiceName` |
+| `--granularity` | `-g` | Time granularity for cost aggregation. Use `MONTHLY` for monthly costs or `DAILY` for daily costs. | `MONTHLY` |
+| `--ago` | `-a` | Number of periods (months for MONTHLY, days for DAILY) to look back from today. For example, use 3 to get the past 3 months. | `1` |
+| `--debug` | - | Enable debug logging to see detailed request/response information. | `False` |
+| `--version` | `-v` | Display the version number and exit. | - |
 
 ### Available Dimensions
 

--- a/README.md
+++ b/README.md
@@ -3,19 +3,36 @@
 [![PyPI version](https://badge.fury.io/py/azurecost.svg)](https://badge.fury.io/py/azurecost)
 [![Build Status](https://github.com/toyama0919/azurecost/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/toyama0919/azurecost/actions/workflows/ci.yml)
 
-Simple and easy command line to view azure costs.
+Simple and easy command line tool to view Azure costs.
 
-Supports python 3.8 and above.
+Supports Python 3.8 and above.
+
+## Installation
+
+```sh
+pip install azurecost
+```
 
 ## Settings
+
+You need to log in with Azure CLI.
 
 ```sh
 az login
 ```
 
-## Examples
+You can specify subscription ID and resource group via environment variables.
 
-#### show cost monthly
+```sh
+export AZURE_SUBSCRIPTION_ID=xxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+export AZURE_RESOURCE_GROUP=xxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+```
+
+## Usage
+
+### Basic Usage
+
+By default, it displays monthly costs aggregated by service name for the past 1 month.
 
 ```bash
 $ azurecost -s my-subscription
@@ -27,11 +44,10 @@ Bandwidth                0          0
 Storage                  0          0
 ```
 
-* You can omit the -s by specifying the environment variable AZURE_SUBSCRIPTION_ID.
+You can omit the `-s` option if you set the subscription ID via environment variable.
 
 ```bash
 $ export AZURE_SUBSCRIPTION_ID=xxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-$ export AZURE_RESOURCE_GROUP=xxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 $ azurecost
 key                   2023-08    2023-09
 ------------------  ---------  ---------
@@ -41,9 +57,11 @@ Bandwidth                0          0
 Storage                  0          0
 ```
 
-#### show cost (Multiple Dimensions)
+### Multiple Dimensions
 
-```
+You can specify multiple dimensions with the `-d` option.
+
+```bash
 $ azurecost -s my-subscription -d ResourceGroup -d ServiceName
 key                                     2023-08    2023-09
 ------------------------------------  ---------  ---------
@@ -58,50 +76,95 @@ RG-7, Bandwidth                            0          0
 RG-7, Storage                              0          0
 ```
 
+### Daily Granularity
+
+Use `-g DAILY` to display daily costs.
+
+```bash
+$ azurecost -s my-subscription -g DAILY
+```
+
+### Specify Time Period
+
+Use the `-a` option to specify how many periods (months or days) ago to fetch data from.
+
+```bash
+# Fetch data from the past 3 months
+$ azurecost -s my-subscription -a 3
+```
+
+### Filter by Resource Group
+
+Use the `-r` option to filter by a specific resource group.
+
+```bash
+$ azurecost -s my-subscription -r my-resource-group
+```
+
+### Command Line Options
+
+| Option | Short | Description | Default |
+|--------|-------|-------------|---------|
+| `--subscription` | `-s` | Subscription display name | `AZURE_SUBSCRIPTION_ID` env var |
+| `--resource-group` | `-r` | Filter by resource group | `AZURE_RESOURCE_GROUP` env var |
+| `--dimensions` | `-d` | Aggregation dimensions (can specify multiple) | `ServiceName` |
+| `--granularity` | `-g` | Aggregation granularity (`MONTHLY`/`DAILY`) | `MONTHLY` |
+| `--ago` | `-a` | How many periods ago to fetch from | `1` |
+| `--debug` | - | Enable debug logging | `False` |
+| `--version` | `-v` | Show version | - |
+
+### Available Dimensions
+
+Examples of dimensions that can be specified with the `-d` option:
+
+- `ResourceGroup` - Resource group
+- `ServiceName` - Service name
+- `ResourceLocation` - Resource location
+- `MeterCategory` - Meter category
+- `ResourceType` - Resource type
+
+For other dimensions, refer to the Azure Cost Management API documentation.
+
 ## Python API
 
-```py
+You can also use it directly from Python code.
+
+```python
+from azurecost import Azurecost
+
 subscription = "my-subscription"
 core = Azurecost(
-    False,
-    "MONTHLY",
-    ["ServiceName"],
+    debug=False,
+    granularity="MONTHLY",
+    dimensions=["ServiceName"],
     subscription_name=subscription,
     # resource_group="my-rg"
 )
-total_results, results = core.get_usage(
-    ago=2,
-)
+total_results, results = core.get_usage(ago=2)
 text = core.convert_tabulate(total_results, results)
 print(text)
 ```
 
-## Installation
+## Development
 
-```sh
-pip install azurecost
-```
+### Setup Test Environment
 
-## CI
-
-### install test package
-
-```
+```bash
 $ ./scripts/ci.sh install
 ```
 
-### test
+### Run Tests
 
-```
+```bash
 $ ./scripts/ci.sh run-test
 ```
 
-flake8 and black and pytest.
+Runs tests with flake8, black, and pytest.
 
-### release pypi
+### Release to PyPI
 
-```
+```bash
 $ ./scripts/ci.sh release
 ```
 
-git tag and pypi release.
+Creates a git tag and releases to PyPI.

--- a/README.md
+++ b/README.md
@@ -132,18 +132,37 @@ You can also use it directly from Python code.
 ```python
 from azurecost import Azurecost
 
-subscription = "my-subscription"
+# Required parameter
 core = Azurecost(
-    debug=False,
-    granularity="MONTHLY",
-    dimensions=["ServiceName"],
-    subscription_name=subscription,
-    # resource_group="my-rg"
+    debug=False,  # Required: Enable debug logging
+    # Optional parameters
+    granularity="MONTHLY",  # Optional: "MONTHLY" or "DAILY" (default: "MONTHLY")
+    dimensions=["ServiceName"],  # Optional: List of dimensions (default: ["ServiceName"])
+    subscription_name="my-subscription",  # Optional: Subscription display name (or use AZURE_SUBSCRIPTION_ID env var)
+    resource_group="my-rg",  # Optional: Resource group filter (or use AZURE_RESOURCE_GROUP env var)
+    # Advanced options (for testing/customization)
+    # credential=None,  # Optional: Azure credential object (default: DefaultAzureCredential())
+    # cost_management_client=None,  # Optional: CostManagementClient instance (for testing)
+    # subscription_client=None,  # Optional: SubscriptionClient instance (for testing)
 )
-total_results, results = core.get_usage(ago=2)
+
+total_results, results = core.get_usage(ago=2)  # ago: number of periods to fetch (default: 1)
 text = core.convert_tabulate(total_results, results)
 print(text)
 ```
+
+### Python API Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `debug` | `bool` | Yes | - | Enable debug logging |
+| `granularity` | `str` | No | `"MONTHLY"` | Aggregation granularity: `"MONTHLY"` or `"DAILY"` |
+| `dimensions` | `list[str]` | No | `["ServiceName"]` | List of dimensions for aggregation |
+| `subscription_name` | `str` | No | `None` | Subscription display name (or use `AZURE_SUBSCRIPTION_ID` env var) |
+| `resource_group` | `str` | No | `None` | Resource group filter (or use `AZURE_RESOURCE_GROUP` env var) |
+| `credential` | `object` | No | `None` | Azure credential object (default: `DefaultAzureCredential()`) |
+| `cost_management_client` | `object` | No | `None` | `CostManagementClient` instance (mainly for testing) |
+| `subscription_client` | `object` | No | `None` | `SubscriptionClient` instance (mainly for testing) |
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ By default, it displays monthly costs aggregated by service name for the past 1 
 
 ```bash
 $ azurecost -s my-subscription
-key                   2023-08    2023-09
+(JPY)                 2023-08    2023-09
 ------------------  ---------  ---------
 total                  492.77      80.28
 Cognitive Services     492.77      80.28
@@ -49,7 +49,7 @@ You can omit the `-s` option if you set the subscription ID via environment vari
 ```bash
 $ export AZURE_SUBSCRIPTION_ID=xxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 $ azurecost
-key                   2023-08    2023-09
+(JPY)                 2023-08    2023-09
 ------------------  ---------  ---------
 total                  492.77      80.28
 Cognitive Services     492.77      80.28
@@ -57,13 +57,15 @@ Bandwidth                0          0
 Storage                  0          0
 ```
 
+**Note:** The currency unit (e.g., `(JPY)`, `(USD)`, `(EUR)`) is automatically determined by your Azure subscription's billing currency settings.
+
 ### Multiple Dimensions
 
 You can specify multiple dimensions with the `-d` option.
 
 ```bash
 $ azurecost -s my-subscription -d ResourceGroup -d ServiceName
-key                                     2023-08    2023-09
+(JPY)                                     2023-08    2023-09
 ------------------------------------  ---------  ---------
 total                                    492.77     426.97
 RG-1, Cognitive Services                 281        366
@@ -112,6 +114,23 @@ $ azurecost -s my-subscription -r my-resource-group
 | `--ago` | `-a` | Number of periods (months for MONTHLY, days for DAILY) to look back from today. For example, use 3 to get the past 3 months. | `1` |
 | `--debug` | - | Enable debug logging to see detailed request/response information. | `False` |
 | `--version` | `-v` | Display the version number and exit. | - |
+
+### Currency Display
+
+The currency unit displayed in the output (e.g., JPY, USD, EUR) is determined by your Azure subscription's billing currency settings. The tool automatically retrieves the currency information from the Azure Cost Management API response and displays it in the output.
+
+**Example output with currency:**
+```bash
+$ azurecost -s my-subscription
+(JPY)                 2023-08    2023-09
+------------------  ---------  ---------
+total                  492.77      80.28
+Cognitive Services     492.77      80.28
+```
+
+The currency is shown in the first column header (e.g., `(JPY)`, `(USD)`, `(EUR)`). This currency matches what you see in the Azure Portal's Cost Analysis view for your subscription.
+
+**Note:** The currency cannot be changed via command-line options as it is determined by your Azure billing account settings. If you need to view costs in a different currency, you would need to change the billing currency in your Azure billing account settings.
 
 ### Available Dimensions
 

--- a/src/azurecost/commands.py
+++ b/src/azurecost/commands.py
@@ -9,33 +9,50 @@ class Mash(object):
 
 
 @click.group(invoke_without_command=True)
-@click.option("--debug/--no-debug", default=False, help="enable debug logging")
-@click.option("--subscription", "-s", type=str, help="subscription display name.")
-@click.option("--resource-group", "-r", type=str, help="resource group filter.")
+@click.option(
+    "--debug/--no-debug",
+    default=False,
+    help="Enable debug logging to see detailed request/response information.",
+)
+@click.option(
+    "--subscription",
+    "-s",
+    type=str,
+    help="Azure subscription display name. Can be omitted if AZURE_SUBSCRIPTION_ID environment variable is set.",
+)
+@click.option(
+    "--resource-group",
+    "-r",
+    type=str,
+    help="Filter costs by a specific resource group. Can be omitted if AZURE_RESOURCE_GROUP environment variable is set.",
+)
 @click.option(
     "--dimensions",
     "-d",
     type=click.Choice(constants.AVAILABLE_DIMENSIONS),
     multiple=True,
     default=constants.DEFAULT_DIMENSIONS,
-    help="dimensions.",
+    help="Dimensions to aggregate costs by (e.g., ResourceGroup, ServiceName). Can be specified multiple times. Default: ServiceName.",
 )
 @click.option(
     "--granularity",
     "-g",
     type=click.Choice(constants.AVAILABLE_GRANULARITY),
     default=constants.DEFAULT_GRANULARITY,
-    help="granularity.",
+    help="Time granularity for cost aggregation. Use MONTHLY for monthly costs or DAILY for daily costs. Default: MONTHLY.",
 )
 @click.option(
     "--ago",
     "-a",
     type=int,
     default=constants.DEFAULT_AGO,
-    help="from_property ${ago} {MONTHLY|DAILY} ago. exp: 1 MONTH ago",
+    help="Number of periods (months for MONTHLY, days for DAILY) to look back from today. For example, use 3 to get the past 3 months. Default: 1.",
 )
 @click.option(
-    "--version/--no-version", "-v", default=False, help="show version. (default: False)"
+    "--version/--no-version",
+    "-v",
+    default=False,
+    help="Display the version number and exit.",
 )
 @click.pass_context
 def cli(

--- a/src/azurecost/core.py
+++ b/src/azurecost/core.py
@@ -28,8 +28,14 @@ class Core:
         self.credential = credential or DefaultAzureCredential()
         self.cost_management_client = cost_management_client or CostManagementClient(
             self.credential,
+            # ClientType header with unique UUID is required to prevent "429 Too Many Requests" errors.
+            # Azure Cost Management API tracks clients by this header. Without a unique identifier,
+            # multiple requests from the same client instance are treated as a single client,
+            # causing rate limiting to be applied more aggressively and leading to 429 errors.
+            # By using a unique UUID per client instance, each instance is tracked separately,
+            # allowing rate limits to be distributed across instances rather than concentrated on one.
             headers={"ClientType": str(uuid.uuid4())},
-            logging_enable=True,
+            logging_enable=True,  # Enable request/response logging for debugging
         )
         self._subscription_client = subscription_client
         self.logger = get_logger(debug)

--- a/src/azurecost/core.py
+++ b/src/azurecost/core.py
@@ -21,13 +21,17 @@ class Core:
         dimensions: list = constants.DEFAULT_DIMENSIONS,
         subscription_name: str = None,
         resource_group: str = None,
+        credential=None,
+        cost_management_client=None,
+        subscription_client=None,
     ):
-        self.credential = DefaultAzureCredential()
-        self.cost_management_client = CostManagementClient(
+        self.credential = credential or DefaultAzureCredential()
+        self.cost_management_client = cost_management_client or CostManagementClient(
             self.credential,
             headers={"ClientType": str(uuid.uuid4())},
             logging_enable=True,
         )
+        self._subscription_client = subscription_client
         self.logger = get_logger(debug)
         self.granularity = granularity
         self.dimensions = dimensions
@@ -85,7 +89,7 @@ class Core:
         view_format_date = "%Y-%m" if self.granularity == "MONTHLY" else "%Y-%m-%d"
         format_date = "%Y-%m-%dT%H:%M:%S" if self.granularity == "MONTHLY" else "%Y%m%d"
         date_key = "BillingMonth" if self.granularity == "MONTHLY" else "UsageDate"
-        currency = results[0].get("Currency")
+        currency = results[0].get("Currency") if results else "USD"
 
         for result in total_results:
             d = datetime.strptime(str(result[date_key]), format_date).strftime(
@@ -115,6 +119,9 @@ class Core:
             d.update(sum_costs)
             costs.append(d)
 
+        if not costs:
+            return "No data available."
+
         # Get the most recent month
         last_time = list(costs[0].keys())[-1]
 
@@ -128,11 +135,13 @@ class Core:
 
     def _get_subscription_id(self, subscription_name: str = None):
         if subscription_name:
-            self.subscription_client = SubscriptionClient(credential=self.credential)
-            for subscription in self.subscription_client.subscriptions.list():
+            if self._subscription_client is None:
+                self._subscription_client = SubscriptionClient(credential=self.credential)
+            for subscription in self._subscription_client.subscriptions.list():
                 if subscription.display_name != subscription_name:
                     continue
                 return subscription.subscription_id
+            raise ValueError(f"Subscription '{subscription_name}' not found.")
         elif os.environ.get("AZURE_SUBSCRIPTION_ID"):
             return os.environ.get("AZURE_SUBSCRIPTION_ID")
         else:

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -61,9 +61,7 @@ def test_cli_with_resource_group(mock_core_class, runner):
     mock_core.convert_tabulate.return_value = "test output"
     mock_core_class.return_value = mock_core
 
-    result = runner.invoke(
-        commands.cli, ["-s", "test-subscription", "-r", "test-rg"]
-    )
+    result = runner.invoke(commands.cli, ["-s", "test-subscription", "-r", "test-rg"])
     assert result.exit_code == 0
     call_args = mock_core_class.call_args
     # Core(debug, granularity, dimensions, subscription, resource_group)

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,4 +1,5 @@
 import pytest
+from unittest.mock import Mock, patch
 from azurecost import commands
 from azurecost import constants
 from click.testing import CliRunner
@@ -13,3 +14,110 @@ def test_show_version(runner):
     result = runner.invoke(commands.cli, ["-v"])
     assert result.exit_code == 0
     assert result.output.strip() == constants.VERSION
+
+
+@patch("azurecost.commands.Core")
+def test_cli_basic_usage(mock_core_class, runner):
+    mock_core = Mock()
+    mock_core.get_usage.return_value = (
+        [{"BillingMonth": "2023-08-01T00:00:00", "Cost": 492.77}],
+        [
+            {
+                "BillingMonth": "2023-08-01T00:00:00",
+                "Cost": 492.77,
+                "ServiceName": "Cognitive Services",
+                "Currency": "USD",
+            }
+        ],
+    )
+    mock_core.convert_tabulate.return_value = "test output"
+    mock_core_class.return_value = mock_core
+
+    result = runner.invoke(commands.cli, ["-s", "test-subscription"])
+    assert result.exit_code == 0
+    assert "test output" in result.output
+    mock_core.get_usage.assert_called_once_with(1)
+
+
+@patch("azurecost.commands.Core")
+def test_cli_with_debug(mock_core_class, runner):
+    mock_core = Mock()
+    mock_core.get_usage.return_value = ([], [])
+    mock_core.convert_tabulate.return_value = "test output"
+    mock_core_class.return_value = mock_core
+
+    result = runner.invoke(commands.cli, ["-s", "test-subscription", "--debug"])
+    assert result.exit_code == 0
+    mock_core_class.assert_called_once()
+    # Check that debug=True was passed as first positional argument
+    call_args = mock_core_class.call_args
+    assert call_args[0][0] is True  # debug parameter
+
+
+@patch("azurecost.commands.Core")
+def test_cli_with_resource_group(mock_core_class, runner):
+    mock_core = Mock()
+    mock_core.get_usage.return_value = ([], [])
+    mock_core.convert_tabulate.return_value = "test output"
+    mock_core_class.return_value = mock_core
+
+    result = runner.invoke(
+        commands.cli, ["-s", "test-subscription", "-r", "test-rg"]
+    )
+    assert result.exit_code == 0
+    call_args = mock_core_class.call_args
+    # Core(debug, granularity, dimensions, subscription, resource_group)
+    assert call_args[0][4] == "test-rg"  # resource_group is 5th positional arg
+
+
+@patch("azurecost.commands.Core")
+def test_cli_with_dimensions(mock_core_class, runner):
+    mock_core = Mock()
+    mock_core.get_usage.return_value = ([], [])
+    mock_core.convert_tabulate.return_value = "test output"
+    mock_core_class.return_value = mock_core
+
+    result = runner.invoke(
+        commands.cli,
+        ["-s", "test-subscription", "-d", "ResourceGroup", "-d", "ServiceName"],
+    )
+    assert result.exit_code == 0
+    call_args = mock_core_class.call_args
+    # Core(debug, granularity, dimensions, subscription, resource_group)
+    dimensions = call_args[0][2]  # dimensions is 3rd positional arg
+    assert "ResourceGroup" in dimensions
+    assert "ServiceName" in dimensions
+
+
+@patch("azurecost.commands.Core")
+def test_cli_with_granularity(mock_core_class, runner):
+    mock_core = Mock()
+    mock_core.get_usage.return_value = ([], [])
+    mock_core.convert_tabulate.return_value = "test output"
+    mock_core_class.return_value = mock_core
+
+    result = runner.invoke(commands.cli, ["-s", "test-subscription", "-g", "DAILY"])
+    assert result.exit_code == 0
+    call_args = mock_core_class.call_args
+    # Core(debug, granularity, dimensions, subscription, resource_group)
+    assert call_args[0][1] == "DAILY"  # granularity is 2nd positional arg
+
+
+@patch("azurecost.commands.Core")
+def test_cli_with_ago(mock_core_class, runner):
+    mock_core = Mock()
+    mock_core.get_usage.return_value = ([], [])
+    mock_core.convert_tabulate.return_value = "test output"
+    mock_core_class.return_value = mock_core
+
+    result = runner.invoke(commands.cli, ["-s", "test-subscription", "-a", "3"])
+    assert result.exit_code == 0
+    mock_core.get_usage.assert_called_once_with(3)
+
+
+@patch("azurecost.commands.Core")
+def test_cli_without_subscription_raises_error(mock_core_class, runner):
+    # Simulate Core raising ValueError when subscription is not found
+    mock_core_class.side_effect = ValueError("Subscription name is required.")
+    result = runner.invoke(commands.cli, [])
+    assert result.exit_code != 0

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -221,7 +221,9 @@ class TestCoreGetSubscriptionId:
         mock_subscription_client = Mock()
         mock_subscription_client.subscriptions.list.return_value = [mock_subscription]
 
-        with pytest.raises(ValueError, match="Subscription 'non-existent-subscription' not found"):
+        with pytest.raises(
+            ValueError, match="Subscription 'non-existent-subscription' not found"
+        ):
             Core(
                 False,
                 subscription_name="non-existent-subscription",

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,0 +1,404 @@
+import pytest
+import os
+from unittest.mock import Mock, MagicMock, patch
+from azurecost.core import Core
+from azurecost import constants
+
+
+class TestCoreConvertTabulate:
+    @patch.dict(os.environ, {"AZURE_SUBSCRIPTION_ID": "test-sub-id"})
+    def test_convert_tabulate_monthly_single_dimension(self):
+        core = Core(
+            False,
+            granularity="MONTHLY",
+            dimensions=["ServiceName"],
+            cost_management_client=Mock(),
+        )
+        core.subscription_id = "test-sub-id"
+
+        total_results = [
+            {"BillingMonth": "2023-08-01T00:00:00", "Cost": 492.77},
+            {"BillingMonth": "2023-09-01T00:00:00", "Cost": 80.28},
+        ]
+        results = [
+            {
+                "BillingMonth": "2023-08-01T00:00:00",
+                "Cost": 492.77,
+                "ServiceName": "Cognitive Services",
+                "Currency": "USD",
+            },
+            {
+                "BillingMonth": "2023-09-01T00:00:00",
+                "Cost": 80.28,
+                "ServiceName": "Cognitive Services",
+                "Currency": "USD",
+            },
+        ]
+
+        output = core.convert_tabulate(total_results, results)
+        assert "total" in output
+        assert "Cognitive Services" in output
+        assert "2023-08" in output
+        assert "2023-09" in output
+        assert "492.77" in output
+        assert "80.28" in output
+
+    @patch.dict(os.environ, {"AZURE_SUBSCRIPTION_ID": "test-sub-id"})
+    def test_convert_tabulate_daily(self):
+        core = Core(
+            False,
+            granularity="DAILY",
+            dimensions=["ServiceName"],
+            cost_management_client=Mock(),
+        )
+        core.subscription_id = "test-sub-id"
+
+        total_results = [
+            {"UsageDate": "20230901", "Cost": 10.5},
+            {"UsageDate": "20230902", "Cost": 20.3},
+        ]
+        results = [
+            {
+                "UsageDate": "20230901",
+                "Cost": 10.5,
+                "ServiceName": "Storage",
+                "Currency": "USD",
+            },
+            {
+                "UsageDate": "20230902",
+                "Cost": 20.3,
+                "ServiceName": "Storage",
+                "Currency": "USD",
+            },
+        ]
+
+        output = core.convert_tabulate(total_results, results)
+        assert "total" in output
+        assert "Storage" in output
+        assert "2023-09-01" in output
+        assert "2023-09-02" in output
+
+    @patch.dict(os.environ, {"AZURE_SUBSCRIPTION_ID": "test-sub-id"})
+    def test_convert_tabulate_multiple_dimensions(self):
+        core = Core(
+            False,
+            granularity="MONTHLY",
+            dimensions=["ResourceGroup", "ServiceName"],
+            cost_management_client=Mock(),
+        )
+        core.subscription_id = "test-sub-id"
+
+        total_results = [
+            {"BillingMonth": "2023-08-01T00:00:00", "Cost": 492.77},
+        ]
+        results = [
+            {
+                "BillingMonth": "2023-08-01T00:00:00",
+                "Cost": 281.0,
+                "ResourceGroup": "RG-1",
+                "ServiceName": "Cognitive Services",
+                "Currency": "USD",
+            },
+            {
+                "BillingMonth": "2023-08-01T00:00:00",
+                "Cost": 211.77,
+                "ResourceGroup": "RG-2",
+                "ServiceName": "Cognitive Services",
+                "Currency": "USD",
+            },
+        ]
+
+        output = core.convert_tabulate(total_results, results)
+        assert "RG-1" in output
+        assert "RG-2" in output
+        assert "Cognitive Services" in output
+
+    @patch.dict(os.environ, {"AZURE_SUBSCRIPTION_ID": "test-sub-id"})
+    def test_convert_tabulate_empty_results(self):
+        core = Core(
+            False,
+            granularity="MONTHLY",
+            dimensions=["ServiceName"],
+            cost_management_client=Mock(),
+        )
+        core.subscription_id = "test-sub-id"
+
+        output = core.convert_tabulate([], [])
+        assert output == "No data available."
+
+    @patch.dict(os.environ, {"AZURE_SUBSCRIPTION_ID": "test-sub-id"})
+    def test_convert_tabulate_with_resource_group(self):
+        core = Core(
+            False,
+            granularity="MONTHLY",
+            dimensions=["ServiceName"],
+            resource_group="test-rg",
+            cost_management_client=Mock(),
+        )
+        core.subscription_id = "test-sub-id"
+
+        total_results = [
+            {"BillingMonth": "2023-08-01T00:00:00", "Cost": 100.0},
+        ]
+        results = [
+            {
+                "BillingMonth": "2023-08-01T00:00:00",
+                "Cost": 100.0,
+                "ServiceName": "Storage",
+                "Currency": "USD",
+            },
+        ]
+
+        output = core.convert_tabulate(total_results, results)
+        assert "Storage" in output
+        assert "100" in output  # tabulate may format as integer
+
+    @patch.dict(os.environ, {"AZURE_SUBSCRIPTION_ID": "test-sub-id"})
+    def test_convert_tabulate_rounds_to_two_decimals(self):
+        core = Core(
+            False,
+            granularity="MONTHLY",
+            dimensions=["ServiceName"],
+            cost_management_client=Mock(),
+        )
+        core.subscription_id = "test-sub-id"
+
+        total_results = [
+            {"BillingMonth": "2023-08-01T00:00:00", "Cost": 123.456789},
+        ]
+        results = [
+            {
+                "BillingMonth": "2023-08-01T00:00:00",
+                "Cost": 123.456789,
+                "ServiceName": "Storage",
+                "Currency": "USD",
+            },
+        ]
+
+        output = core.convert_tabulate(total_results, results)
+        # Should round to 2 decimal places
+        assert "123.46" in output or "123.45" in output
+
+
+class TestCoreGetSubscriptionId:
+    def test_get_subscription_id_from_name(self):
+        mock_subscription = Mock()
+        mock_subscription.display_name = "test-subscription"
+        mock_subscription.subscription_id = "test-sub-id-123"
+
+        mock_subscription_client = Mock()
+        mock_subscription_client.subscriptions.list.return_value = [mock_subscription]
+
+        core = Core(
+            False,
+            subscription_name="test-subscription",
+            cost_management_client=Mock(),
+            subscription_client=mock_subscription_client,
+        )
+        assert core.subscription_id == "test-sub-id-123"
+
+    def test_get_subscription_id_from_env(self):
+        with patch.dict(os.environ, {"AZURE_SUBSCRIPTION_ID": "env-sub-id-456"}):
+            core = Core(
+                False,
+                cost_management_client=Mock(),
+            )
+            assert core.subscription_id == "env-sub-id-456"
+
+    def test_get_subscription_id_raises_error_when_not_found(self):
+        with patch.dict(os.environ, {}, clear=True):
+            with pytest.raises(ValueError, match="Subscription name is required"):
+                Core(
+                    False,
+                    cost_management_client=Mock(),
+                )
+
+    def test_get_subscription_id_not_found_by_name(self):
+        mock_subscription = Mock()
+        mock_subscription.display_name = "other-subscription"
+        mock_subscription.subscription_id = "other-sub-id"
+
+        mock_subscription_client = Mock()
+        mock_subscription_client.subscriptions.list.return_value = [mock_subscription]
+
+        with pytest.raises(ValueError, match="Subscription 'non-existent-subscription' not found"):
+            Core(
+                False,
+                subscription_name="non-existent-subscription",
+                cost_management_client=Mock(),
+                subscription_client=mock_subscription_client,
+            )
+
+
+class TestCoreGetUsage:
+    @patch.dict(os.environ, {"AZURE_SUBSCRIPTION_ID": "test-sub-id"})
+    def test_get_usage_monthly(self):
+        mock_col1 = Mock()
+        mock_col1.name = "BillingMonth"
+        mock_col2 = Mock()
+        mock_col2.name = "Cost"
+        mock_usage_total = Mock()
+        mock_usage_total.columns = [mock_col1, mock_col2]
+        mock_usage_total.rows = [
+            ["2023-08-01T00:00:00", 492.77],
+            ["2023-09-01T00:00:00", 80.28],
+        ]
+
+        mock_col3 = Mock()
+        mock_col3.name = "BillingMonth"
+        mock_col4 = Mock()
+        mock_col4.name = "Cost"
+        mock_col5 = Mock()
+        mock_col5.name = "ServiceName"
+        mock_usage_dimensions = Mock()
+        mock_usage_dimensions.columns = [mock_col3, mock_col4, mock_col5]
+        mock_usage_dimensions.rows = [
+            ["2023-08-01T00:00:00", 492.77, "Cognitive Services"],
+            ["2023-09-01T00:00:00", 80.28, "Cognitive Services"],
+        ]
+
+        mock_client = Mock()
+        mock_client.query.usage.side_effect = [mock_usage_total, mock_usage_dimensions]
+
+        core = Core(
+            False,
+            granularity="MONTHLY",
+            dimensions=["ServiceName"],
+            cost_management_client=mock_client,
+        )
+
+        total_results, results = core.get_usage(ago=1)
+
+        assert len(total_results) == 2
+        assert total_results[0]["BillingMonth"] == "2023-08-01T00:00:00"
+        assert total_results[0]["Cost"] == 492.77
+        assert len(results) == 2
+        assert results[0]["ServiceName"] == "Cognitive Services"
+
+        # Verify API was called correctly
+        assert mock_client.query.usage.call_count == 2
+
+    @patch.dict(os.environ, {"AZURE_SUBSCRIPTION_ID": "test-sub-id"})
+    def test_get_usage_daily(self):
+        mock_col1 = Mock()
+        mock_col1.name = "UsageDate"
+        mock_col2 = Mock()
+        mock_col2.name = "Cost"
+        mock_usage_total = Mock()
+        mock_usage_total.columns = [mock_col1, mock_col2]
+        mock_usage_total.rows = [
+            ["20230901", 10.5],
+        ]
+
+        mock_col3 = Mock()
+        mock_col3.name = "UsageDate"
+        mock_col4 = Mock()
+        mock_col4.name = "Cost"
+        mock_col5 = Mock()
+        mock_col5.name = "ServiceName"
+        mock_usage_dimensions = Mock()
+        mock_usage_dimensions.columns = [mock_col3, mock_col4, mock_col5]
+        mock_usage_dimensions.rows = [
+            ["20230901", 10.5, "Storage"],
+        ]
+
+        mock_client = Mock()
+        mock_client.query.usage.side_effect = [mock_usage_total, mock_usage_dimensions]
+
+        core = Core(
+            False,
+            granularity="DAILY",
+            dimensions=["ServiceName"],
+            cost_management_client=mock_client,
+        )
+
+        total_results, results = core.get_usage(ago=1)
+
+        assert len(total_results) == 1
+        assert total_results[0]["UsageDate"] == "20230901"
+        assert len(results) == 1
+        assert results[0]["ServiceName"] == "Storage"
+
+    @patch.dict(os.environ, {"AZURE_SUBSCRIPTION_ID": "test-sub-id"})
+    def test_get_usage_with_resource_group(self):
+        mock_col1 = Mock()
+        mock_col1.name = "BillingMonth"
+        mock_col2 = Mock()
+        mock_col2.name = "Cost"
+        mock_usage_total = Mock()
+        mock_usage_total.columns = [mock_col1, mock_col2]
+        mock_usage_total.rows = [
+            ["2023-08-01T00:00:00", 100.0],
+        ]
+
+        mock_col3 = Mock()
+        mock_col3.name = "BillingMonth"
+        mock_col4 = Mock()
+        mock_col4.name = "Cost"
+        mock_col5 = Mock()
+        mock_col5.name = "ServiceName"
+        mock_usage_dimensions = Mock()
+        mock_usage_dimensions.columns = [mock_col3, mock_col4, mock_col5]
+        mock_usage_dimensions.rows = [
+            ["2023-08-01T00:00:00", 100.0, "Storage"],
+        ]
+
+        mock_client = Mock()
+        mock_client.query.usage.side_effect = [mock_usage_total, mock_usage_dimensions]
+
+        core = Core(
+            False,
+            granularity="MONTHLY",
+            dimensions=["ServiceName"],
+            resource_group="test-rg",
+            cost_management_client=mock_client,
+        )
+
+        total_results, results = core.get_usage(ago=1)
+
+        # Verify scope includes resource group
+        calls = mock_client.query.usage.call_args_list
+        assert "/resourceGroups/test-rg" in str(calls[0])
+
+    @patch.dict(os.environ, {"AZURE_SUBSCRIPTION_ID": "test-sub-id"})
+    def test_get_usage_multiple_dimensions(self):
+        mock_col1 = Mock()
+        mock_col1.name = "BillingMonth"
+        mock_col2 = Mock()
+        mock_col2.name = "Cost"
+        mock_usage_total = Mock()
+        mock_usage_total.columns = [mock_col1, mock_col2]
+        mock_usage_total.rows = [
+            ["2023-08-01T00:00:00", 492.77],
+        ]
+
+        mock_col3 = Mock()
+        mock_col3.name = "BillingMonth"
+        mock_col4 = Mock()
+        mock_col4.name = "Cost"
+        mock_col5 = Mock()
+        mock_col5.name = "ResourceGroup"
+        mock_col6 = Mock()
+        mock_col6.name = "ServiceName"
+        mock_usage_dimensions = Mock()
+        mock_usage_dimensions.columns = [mock_col3, mock_col4, mock_col5, mock_col6]
+        mock_usage_dimensions.rows = [
+            ["2023-08-01T00:00:00", 281.0, "RG-1", "Cognitive Services"],
+            ["2023-08-01T00:00:00", 211.77, "RG-2", "Cognitive Services"],
+        ]
+
+        mock_client = Mock()
+        mock_client.query.usage.side_effect = [mock_usage_total, mock_usage_dimensions]
+
+        core = Core(
+            False,
+            granularity="MONTHLY",
+            dimensions=["ResourceGroup", "ServiceName"],
+            cost_management_client=mock_client,
+        )
+
+        total_results, results = core.get_usage(ago=1)
+
+        assert len(results) == 2
+        assert results[0]["ResourceGroup"] == "RG-1"
+        assert results[0]["ServiceName"] == "Cognitive Services"

--- a/tests/test_date_util.py
+++ b/tests/test_date_util.py
@@ -1,0 +1,41 @@
+import pytest
+from datetime import datetime, timezone
+from azurecost.date_util import DateUtil
+
+
+class TestDateUtil:
+    def test_get_start_and_end_monthly(self):
+        start, end = DateUtil.get_start_and_end("MONTHLY", 1)
+        assert isinstance(start, datetime)
+        assert isinstance(end, datetime)
+        assert start.tzinfo == timezone.utc
+        assert end.tzinfo == timezone.utc
+        assert start.day == 1
+        assert start < end
+
+    def test_get_start_and_end_monthly_multiple_months(self):
+        start, end = DateUtil.get_start_and_end("MONTHLY", 3)
+        assert isinstance(start, datetime)
+        assert isinstance(end, datetime)
+        assert start.day == 1
+        # Should be approximately 90 days ago
+        diff = end - start
+        assert 85 <= diff.days <= 95
+
+    def test_get_start_and_end_daily(self):
+        start, end = DateUtil.get_start_and_end("DAILY", 1)
+        assert isinstance(start, datetime)
+        assert isinstance(end, datetime)
+        assert start.tzinfo == timezone.utc
+        assert end.tzinfo == timezone.utc
+        # Should be approximately 1 day ago
+        diff = end - start
+        assert 0 <= diff.days <= 2
+
+    def test_get_start_and_end_daily_multiple_days(self):
+        start, end = DateUtil.get_start_and_end("DAILY", 7)
+        assert isinstance(start, datetime)
+        assert isinstance(end, datetime)
+        # Should be approximately 7 days ago
+        diff = end - start
+        assert 6 <= diff.days <= 8


### PR DESCRIPTION
This PR significantly improves the project by adding extensive test coverage and enhancing the README documentation with detailed usage examples and API reference.

## Changes

### Documentation Improvements
- Enhanced README.md with comprehensive usage guide including installation, setup, and multiple usage examples
- Added detailed command line options table with descriptions and defaults
- Added Python API documentation with parameter reference and usage examples
- Improved grammar and consistency throughout (e.g., "Azure" capitalization, "Python" capitalization)
- Added examples for daily granularity, time periods, resource group filtering, and multiple dimensions
- Clarified environment variable usage and subscription/resource group configuration

### Test Coverage
- Added comprehensive test suite for `commands.py` covering:
  - Basic CLI usage
  - Debug mode
  - Resource group filtering
  - Multiple dimensions
  - Granularity options (MONTHLY/DAILY)
  - Time period (`--ago` option)
  - Error handling for missing subscriptions
- Added comprehensive test suite for `core.py` covering:
  - `convert_tabulate()` method with monthly/daily granularity, single/multiple dimensions, empty results
  - `_get_subscription_id()` method with subscription name lookup, environment variables, and error cases
  - `get_usage()` method with various configurations
- Added test suite for `date_util.py` covering date range calculations for both MONTHLY and DAILY granularity

### Code Improvements
- Enhanced command line help messages with more detailed descriptions for all options
- Added defensive programming to handle empty results in `convert_tabulate()` (returns "No data available.")
- Improved error handling in `_get_subscription_id()` to raise clear error when subscription not found
- Added support for dependency injection in `Core` class constructor (credential, cost_management_client, subscription_client parameters) for better testability
- Fixed edge case where currency defaults to "USD" if no results available
- Added detailed comments explaining the ClientType header UUID requirement for Azure API rate limiting
- Improved help text formatting and clarity for all CLI options